### PR TITLE
Swashbuckler Favored Class Bonuses

### DIFF
--- a/ZFavoredClass/Custom/bonus_charmed_life.json
+++ b/ZFavoredClass/Custom/bonus_charmed_life.json
@@ -1,0 +1,7 @@
+{
+    feature: "57b8c544535f40918881cf4000021a40",
+    partial: "",
+    divisor: 4,
+    classes: ["b1c7989ee7f04af8b11309f02b34cb4a"],
+    races: ["ef35a22c9a27da345a4528f0d5889157", "b0c3ef2729c498f47970bb50fa1acd30", "b3646842ffbd01643ab4dac7479b20b0"]
+}

--- a/ZFavoredClass/Custom/bonus_panache.json
+++ b/ZFavoredClass/Custom/bonus_panache.json
@@ -1,0 +1,7 @@
+{
+    feature: "89b0082da456424380b5c541f63eee41",
+    partial: "",
+    divisor: 4,
+    classes: ["b1c7989ee7f04af8b11309f02b34cb4a"],
+    races: ["25a5878d125338244896ebd3238226c8", "0a5d473ead98b0646b94495af250fdc4"]
+}


### PR DESCRIPTION
Adding in favored class bonuses for Swashbuckler:
- Bonus panache for Humans and Elves
- Bonus charmed life for Gnomes, Halflings and Half-Elves